### PR TITLE
Added testing and a few tweaks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Bas ten Berge
 Basil Shubin
 Ben Timby
 Benjamin Jorand
+Benjamin Howes
 Biel Massot
 Björn Andersson
 Bojan Mihelac

--- a/allauth/socialaccount/providers/apple/provider.py
+++ b/allauth/socialaccount/providers/apple/provider.py
@@ -1,10 +1,12 @@
 from allauth.account.models import EmailAddress
+from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class AppleProvider(OAuth2Provider):
     id = 'apple'
     name = 'Apple'
+    account_class = ProviderAccount
 
     def extract_uid(self, data):
         return str(data['sub'])
@@ -12,9 +14,6 @@ class AppleProvider(OAuth2Provider):
     def extract_common_fields(self, data):
         return dict(
             email=data.get('email'),
-            username=data.get('username', ''),
-            name=((data.get('first_name', '') + ' ' +
-                  data.get('last_name', '')).strip()),
         )
 
     def extract_email_addresses(self, data):

--- a/allauth/socialaccount/providers/apple/views.py
+++ b/allauth/socialaccount/providers/apple/views.py
@@ -27,9 +27,14 @@ class AppleOAuth2Adapter(OAuth2Adapter):
     public_key_url = 'https://appleid.apple.com/auth/keys'
 
     def get_public_key(self, id_token):
+        """
+        Get the public key which matches the `kid` in the id_token header.
+        """
         kid = jwt.get_unverified_header(id_token)['kid']
-        apple_public_key = [d for d in requests.get(self.public_key_url).json()[
-            'keys'] if d['kid'] == kid][0]
+        apple_public_key = [
+            d for d in requests.get(self.public_key_url).json()['keys']
+            if d['kid'] == kid
+        ][0]
         public_key = jwt.algorithms.RSAAlgorithm.from_jwk(
             json.dumps(apple_public_key)
         )
@@ -50,7 +55,7 @@ class AppleOAuth2Adapter(OAuth2Adapter):
         token.user_data = jwt.decode(
             data['id_token'],
             public_key,
-            algorithm="RS256",
+            algorithms=["RS256"],
             verify=True,
             audience=client_id
         )

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -124,7 +124,7 @@ Development callback URL
 Apple
 ---------
 
-App registration (create App ID and related Service ID here)
+App registration (create an App ID and then a related Service ID here)
     https://developer.apple.com/account/resources/certificates/list
 
 Private Key registration (be sure to save it)


### PR DESCRIPTION
@0leg5ergeev I've added unit testing to the PR and a few minor changes:

- removed the `name` scope since we can't make use of it at the moment. With this scope turned on, apple allows the user to edit their name and send that to the app. This is not much use when we cannot pick that up. As such, it's easier to just let them enter their name as the django site needs it.
- A few very minor code changes to make things a bit more readable in some places

## General

 - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [x] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [x] Add documentation to `docs/providers.rst`.
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`.
