### PR TITLE
Test removing caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,6 @@ matrix:
     - python: 3.8
       env: TOXENV=py38-djangomaster
 
-cache:
-  directories:
-    - $HOME/.cache/pip
-    - $TRAVIS_BUILD_DIR/.tox
-
 install:
   - if [[ $TOXENV == "standardjs" ]]; then nvm install 8; fi
   - pip install --upgrade pip wheel setuptools


### PR DESCRIPTION
Remove caching because new requirements in setup.py do not seem to be installed at the moment

This probably needs to be changed/reverted before the main PR is merged
