### PR TITLE
Add sign in with apple method

### DIFF
--- a/allauth/socialaccount/providers/apple/client.py
+++ b/allauth/socialaccount/providers/apple/client.py
@@ -30,7 +30,7 @@ class AppleOAuth2Client(OAuth2Client):
         claims = {
             'iss': self.key,
             'aud': 'https://appleid.apple.com',
-            'sub': self.consumer_key,
+            'sub': self.get_client_id(),
             'iat': now,
             'exp': now + timedelta(hours=1),
         }
@@ -40,11 +40,15 @@ class AppleOAuth2Client(OAuth2Client):
         ).decode('utf-8')
         return client_secret
 
+    def get_client_id(self):
+        """ We support multiple client_ids, but use the first one for api calls """
+        return self.consumer_key.split(',')[0]
+
     def get_access_token(self, code):
         url = self.access_token_url
         client_secret = self.generate_client_secret()
         data = {
-            'client_id': self.consumer_key,
+            'client_id': self.get_client_id(),
             'code': code,
             'grant_type': 'authorization_code',
             'redirect_uri': self.callback_url,
@@ -68,7 +72,7 @@ class AppleOAuth2Client(OAuth2Client):
 
     def get_redirect_url(self, authorization_url, extra_params):
         params = {
-            'client_id': self.consumer_key,
+            'client_id': self.get_client_id(),
             'redirect_uri': self.callback_url,
             'response_mode': 'form_post',
             'scope': ' '.join([Scope.EMAIL]),

--- a/allauth/socialaccount/providers/apple/views.py
+++ b/allauth/socialaccount/providers/apple/views.py
@@ -44,7 +44,7 @@ class AppleOAuth2Adapter(OAuth2Adapter):
 
     def get_client_id(self, provider):
         app = SocialApp.objects.get(provider=provider.id)
-        return app.client_id
+        return [aud.strip() for aud in app.client_id.split(",")]
 
     def parse_token(self, data):
         try:
@@ -53,14 +53,14 @@ class AppleOAuth2Adapter(OAuth2Adapter):
 
             public_key = self.get_public_key(data["id_token"])
             provider = self.get_provider()
-            client_id = self.get_client_id(provider)
+            allowed_auds = self.get_client_id(provider)
 
             token.user_data = jwt.decode(
                 data["id_token"],
                 public_key,
                 algorithms=["RS256"],
                 verify=True,
-                audience=client_id,
+                audience=allowed_auds,
             )
             expires_in = data.get(self.expires_in_key, None)
             if expires_in:

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -136,7 +136,7 @@ Development callback URL
 You'll need to specify Developer's and Application's data:
 
 In Social App:
-    Client ID: Service ID identifier
+    Client ID: Service ID identifier. In the case that you have an app too, this field should be a comma separated list, with the service identifier first, followed by any app identifiers.
     Secret Key: Key ID
     Key: Member ID/App ID Prefix (find it below your name at the top right corner of the
 page, or it’s your App ID Prefix in your App ID)


### PR DESCRIPTION
Hi @0leg5ergeev 

We have an iOS app, which is hooking in to our django server. I discovered that in this instance it's not possible to have the same `aud` in the JWT as from the web login.

As such, I've made it possible for the "Client id" field to be a comma-separated list of identifiers so that the identifier for both the Service and the App can be included and validated in the `jwt.decode()` call.

Tested and working with our app :ok_hand: 