### PR TITLE
Re-add a redirect, with an apple specific session

### DIFF
--- a/allauth/socialaccount/providers/apple/apple_session.py
+++ b/allauth/socialaccount/providers/apple/apple_session.py
@@ -1,6 +1,5 @@
 from importlib import import_module
 
-from django.urls import reverse
 from django.conf import settings
 from django.utils.cache import patch_vary_headers
 
@@ -29,7 +28,7 @@ def persist_apple_session(request, response):
         expires=None,
         domain=settings.SESSION_COOKIE_DOMAIN,
         # The cookie is only needed on this endpoint
-        path=reverse("apple_finish_callback"),
+        path=response.url,
         secure=True,
         httponly=None,
         samesite=settings.SESSION_COOKIE_SAMESITE,

--- a/allauth/socialaccount/providers/apple/apple_session.py
+++ b/allauth/socialaccount/providers/apple/apple_session.py
@@ -1,0 +1,36 @@
+from importlib import import_module
+
+from django.urls import reverse
+from django.conf import settings
+from django.utils.cache import patch_vary_headers
+
+APPLE_SESSION_COOKIE_NAME = "apple-login-session"
+
+engine = import_module(settings.SESSION_ENGINE)
+SessionStore = engine.SessionStore
+
+def add_apple_session(request):
+    """
+    Fetch an apple login session
+    """
+    session_key = request.COOKIES.get(APPLE_SESSION_COOKIE_NAME)
+    request.apple_login_session = SessionStore(session_key)
+
+def persist_apple_session(request, response):
+    """
+    Save `request.apple_login_session` and set the cookie
+    """
+    patch_vary_headers(response, ('Cookie',))
+    request.apple_login_session.save()
+    response.set_cookie(
+        APPLE_SESSION_COOKIE_NAME,
+        request.apple_login_session.session_key,
+        max_age=None,
+        expires=None,
+        domain=settings.SESSION_COOKIE_DOMAIN,
+        # The cookie is only needed on this endpoint
+        path=reverse("apple_finish_callback"),
+        secure=True,
+        httponly=None,
+        samesite=settings.SESSION_COOKIE_SAMESITE,
+    )

--- a/allauth/socialaccount/providers/apple/provider.py
+++ b/allauth/socialaccount/providers/apple/provider.py
@@ -17,10 +17,8 @@ class AppleProvider(OAuth2Provider):
             "email": data.get("email")
         }
 
-        user_scope_data = data["user_scope_data"]
-        # Apple provide user name in nested json
-        # So check whether there is name
-        name = user_scope_data.get("name")
+        # If the name was provided
+        name = data.get("name")
         if name:
             fields["first_name"] = name.get("firstName", "")
             fields["last_name"] = name.get("lastName", "")

--- a/allauth/socialaccount/providers/apple/urls.py
+++ b/allauth/socialaccount/providers/apple/urls.py
@@ -1,6 +1,14 @@
 from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+from django.urls import path
 
 from .provider import AppleProvider
-
+from .views import oauth2_finish_login
 
 urlpatterns = default_urlpatterns(AppleProvider)
+urlpatterns += [
+    path(
+        AppleProvider.get_slug() + '/login/callback/finish/',
+        oauth2_finish_login,
+        name="apple_finish_callback"
+    ),
+]

--- a/allauth/socialaccount/providers/apple/views.py
+++ b/allauth/socialaccount/providers/apple/views.py
@@ -80,7 +80,7 @@ class AppleOAuth2Adapter(OAuth2Adapter):
         token = SocialToken(
             token=data["access_token"],
         )
-        token.token_secret=data["refresh_token"]
+        token.token_secret=data.get("refresh_token", "")
 
         expires_in = data.get(self.expires_in_key)
         if expires_in:

--- a/allauth/socialaccount/providers/apple/views.py
+++ b/allauth/socialaccount/providers/apple/views.py
@@ -99,7 +99,10 @@ class AppleOAuth2Adapter(OAuth2Adapter):
 
         # We can safely remove the apple login session now
         # Note: The cookie will remain, but it's set to delete on browser close
-        request.apple_login_session.delete()
+        try:
+            request.apple_login_session.delete()
+        except AttributeError:
+            pass
 
         return login
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -142,13 +142,6 @@ In Social App:
 page, or it’s your App ID Prefix in your App ID)
     Cert: The contents of your private key, including "-----BEGIN/END PRIVATE KEY-----" and line breaks
 
-In your django settings, the means by which apple returns data to your app requires that cross-site cookies are allowed. This can be done in your Django settings:
-
-.. code-block:: python
-
-    SESSION_COOKIE_SAMESITE = None  # Needed to allow `form_post` response from apple
-    SESSION_COOKIE_SECURE = True # Required when setting SameSite=None
-
 
 Auth0
 -----


### PR DESCRIPTION
In this PR, I've reverted us to using a `POST`->`GET` redirect in order that we don't have to relax the `SESSION_COOKIE_SAMESITE` policy, however, I wanted to keep the benefits we'd gotten from being able to use the `user` scope from the post response.

After some internal discussion, and a read of https://dev.to/costerad/sign-in-with-apple-implementation-hurdles-761, we decided to try using an apple specific sign-in session.  The only difference is that we use the apple specific cookie after a successful login for the reason that it's much more compatible with allauth's structure.

Pros:
1. No cookie policy relaxation
2. Coaxes the apple response in to acting more like a oauth2 response with the the POST endpoint
3. Safely stores the apple login response - I believe this approach provides the best security by virtue of leaning on django's existing session management as far as possible.

Cons:
1. Additional redirect
2. Some complexity