### PR TITLE
fix: ensure bool in apple sign in

### DIFF
--- a/allauth/socialaccount/providers/apple/provider.py
+++ b/allauth/socialaccount/providers/apple/provider.py
@@ -28,11 +28,14 @@ class AppleProvider(OAuth2Provider):
     def extract_email_addresses(self, data):
         ret = []
         email = data.get('email')
+        verified = data.get('email_verified')
+        if not isinstance(verified, bool):
+            verified = verified.lower() == 'true'
         if email:
             ret.append(
                 EmailAddress(
                     email=email,
-                    verified=data.get('email_verified'),
+                    verified=verified,
                     primary=True,
                 )
             )


### PR DESCRIPTION
I encountered this issue when setting this up; creating a new account resulted in an error due to this variable not being a boolean as expected. Account creation was successful with this fix.

I'm not sure whether this is idiosyncratic – maybe you'll want to test further. Maybe Apple is returning a string rather than logical boolean in JSON.