### PR TITLE
Fix issue with apple session cookie on safari browsers

### DIFF
--- a/allauth/socialaccount/providers/apple/apple_session.py
+++ b/allauth/socialaccount/providers/apple/apple_session.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils.cache import patch_vary_headers
@@ -8,12 +9,14 @@ APPLE_SESSION_COOKIE_NAME = "apple-login-session"
 engine = import_module(settings.SESSION_ENGINE)
 SessionStore = engine.SessionStore
 
+
 def add_apple_session(request):
     """
     Fetch an apple login session
     """
     session_key = request.COOKIES.get(APPLE_SESSION_COOKIE_NAME)
     request.apple_login_session = SessionStore(session_key)
+
 
 def persist_apple_session(request, response):
     """
@@ -28,7 +31,7 @@ def persist_apple_session(request, response):
         expires=None,
         domain=settings.SESSION_COOKIE_DOMAIN,
         # The cookie is only needed on this endpoint
-        path=response.url,
+        path=urlparse(response.url).path,
         secure=True,
         httponly=None,
         samesite=settings.SESSION_COOKIE_SAMESITE,

--- a/allauth/socialaccount/providers/apple/client.py
+++ b/allauth/socialaccount/providers/apple/client.py
@@ -1,8 +1,6 @@
 import requests
 from datetime import datetime, timedelta
-from urllib.parse import parse_qsl
-
-from django.utils.http import urlencode
+from urllib.parse import parse_qsl, quote, urlencode
 
 import jwt
 
@@ -81,4 +79,4 @@ class AppleOAuth2Client(OAuth2Client):
         if self.state:
             params['state'] = self.state
         params.update(extra_params)
-        return '%s?%s' % (authorization_url, urlencode(params))
+        return '%s?%s' % (authorization_url, urlencode(params, quote_via=quote))


### PR DESCRIPTION
This fixes an issue where path was being incorrectly set on the apple session cookie breaking login in safari browsers. I've checked and could login on imac / iphone / ipad. 

Additionally a fix via @madprime  to correctly encode params in redirect url.

https://github.com/pennersr/django-allauth/pull/2424#issuecomment-616333211