### PR TITLE
fix(apple): Fix a bug when using response_mode=form_get parameter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -105,6 +105,7 @@ Markus Thielen
 Martin Bächtold
 Mauro Stettler
 Morgante Pell
+Myles Braithwaite
 Nariman Gharib
 Niklas A Emanuelsson
 Oleg Sergeev

--- a/allauth/socialaccount/providers/apple/provider.py
+++ b/allauth/socialaccount/providers/apple/provider.py
@@ -27,11 +27,17 @@ class AppleProvider(OAuth2Provider):
 
     def extract_email_addresses(self, data):
         ret = []
-        email = data.get('email')
-        verified = data.get('email_verified')
-        if not isinstance(verified, bool):
-            verified = verified.lower() == 'true'
+
+        # When we use response_mode=form_get we will not get an `email` or
+        # `email_verified` back from Apple.
+        email = data.get("email")
+
         if email:
+            verified = data.get("email_verified", "")
+
+            if not isinstance(verified, bool):
+                verified = verified.lower() == 'true'
+
             ret.append(
                 EmailAddress(
                     email=email,
@@ -39,6 +45,7 @@ class AppleProvider(OAuth2Provider):
                     primary=True,
                 )
             )
+
         return ret
 
     def get_default_scope(self):


### PR DESCRIPTION
Fixes a bug when we use `response_mode=form_get`, as Apple will not provided an email address when using `GET`.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [x] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [x] Add documentation to `docs/providers.rst`.
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`.
